### PR TITLE
Add protobuf Transmit/Receive methods

### DIFF
--- a/bpf.go
+++ b/bpf.go
@@ -1,6 +1,9 @@
 package lcm
 
-import "golang.org/x/net/bpf"
+import (
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/bpf"
+)
 
 // indexOfUDPPayload is the first byte index of the payload in a a UDP packet.
 const indexOfUDPPayload = 8
@@ -47,4 +50,13 @@ func ShortMessageChannelFilter(channels ...string) []bpf.Instruction {
 	// no channel match, reject package
 	program = append(program, bpf.RetConstant{Val: 0})
 	return program
+}
+
+// ShortProtoMessageFilter accepts LCM short messages where the channel equals any of the proto message names.
+func ShortProtoMessageFilter(msgs ...proto.Message) []bpf.Instruction {
+	channels := make([]string, 0, len(msgs))
+	for _, msg := range msgs {
+		channels = append(channels, proto.MessageName(msg))
+	}
+	return ShortMessageChannelFilter(channels...)
 }

--- a/transmitter.go
+++ b/transmitter.go
@@ -61,11 +61,16 @@ func DialMulticastUDP(ctx context.Context, transmitterOpts ...TransmitterOption)
 	return tx, nil
 }
 
+// TransmitProto transmits a protobuf message on the channel given by the message's fully-qualified name.
+func (t *Transmitter) TransmitProto(ctx context.Context, m proto.Message) error {
+	return t.TransmitProtoOnChannel(ctx, proto.MessageName(m), m)
+}
+
 // TransmitProto transmits a protobuf message.
-func (t *Transmitter) TransmitProto(ctx context.Context, channel string, m proto.Message) error {
+func (t *Transmitter) TransmitProtoOnChannel(ctx context.Context, channel string, m proto.Message) error {
 	t.protoBuf.Reset()
 	if err := t.protoBuf.Marshal(m); err != nil {
-		return xerrors.Errorf("transmit proto: %w", err)
+		return xerrors.Errorf("transmit proto on channel %s: %w", channel, err)
 	}
 	return t.Transmit(ctx, channel, t.protoBuf.Bytes())
 }


### PR DESCRIPTION
Using the fully-qualified proto name as the channel, it's possible to
receive/transmit protobuf messages without having to specify a channel.