### PR TITLE
Migrate from xerrors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,4 @@ require (
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
-	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 )

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 h1:1Fzlr8kkDLQwqMP8GxrhptBLqZG/EDpiATneiZHY998=
 golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/pkg/lcmlog/message.go
+++ b/pkg/lcmlog/message.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"strings"
 	"time"
-
-	"golang.org/x/xerrors"
 )
 
 // from: https://lcm-proj.github.io/log_file_format.html
@@ -125,20 +123,20 @@ func scanLogMessages(data []byte, atEOF bool) (advance int, token []byte, err er
 	}
 	if len(data) < lengthOfHeader {
 		if atEOF {
-			return 0, nil, xerrors.Errorf("partial message at end of log file: %s", hex.EncodeToString(data))
+			return 0, nil, fmt.Errorf("partial message at end of log file: %s", hex.EncodeToString(data))
 		}
 		return 0, nil, nil
 	}
 	actualSyncWord := binary.BigEndian.Uint32(data[indexOfSyncWord:endOfSyncWord])
 	if actualSyncWord != syncWord {
-		return 0, nil, xerrors.Errorf("unexpected sync word: %#x", actualSyncWord)
+		return 0, nil, fmt.Errorf("unexpected sync word: %#x", actualSyncWord)
 	}
 	channelLength := binary.BigEndian.Uint32(data[indexOfChannelLength:endOfChannelLength])
 	dataLength := binary.BigEndian.Uint32(data[indexOfDataLength:endOfDataLength])
 	messageLength := lengthOfHeader + int(channelLength) + int(dataLength)
 	if len(data) < messageLength {
 		if atEOF {
-			return 0, nil, xerrors.Errorf("partial message at end of log file: %s", hex.EncodeToString(data))
+			return 0, nil, fmt.Errorf("partial message at end of log file: %s", hex.EncodeToString(data))
 		}
 		return 0, nil, nil
 	}

--- a/pkg/lz4/lz4.go
+++ b/pkg/lz4/lz4.go
@@ -2,9 +2,9 @@ package lz4
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/pierrec/lz4/v3"
-	"golang.org/x/xerrors"
 )
 
 const maxMessageSize = 65565 * 2 // on the safe side
@@ -32,10 +32,10 @@ func (c *Compressor) Compress(data []byte) ([]byte, error) {
 	c.buffer.Reset()
 	c.writer.Reset(c.buffer)
 	if _, err := c.writer.Write(data); err != nil {
-		return nil, xerrors.Errorf("lz4 compress write: %w", err)
+		return nil, fmt.Errorf("lz4 compress write: %w", err)
 	}
 	if err := c.writer.Close(); err != nil {
-		return nil, xerrors.Errorf("lz4 compress close: %w", err)
+		return nil, fmt.Errorf("lz4 compress close: %w", err)
 	}
 	return c.buffer.Bytes(), nil
 }
@@ -55,7 +55,7 @@ func (d *Decompressor) Decompress(data []byte) ([]byte, error) {
 	d.reader.Reset(bytes.NewBuffer(data))
 	n, err := d.reader.Read(d.buf)
 	if err != nil {
-		return nil, xerrors.Errorf("lz4 decompress read: %w", err)
+		return nil, fmt.Errorf("lz4 decompress read: %w", err)
 	}
 	return d.buf[:n], nil
 }

--- a/transmitter.go
+++ b/transmitter.go
@@ -2,12 +2,12 @@ package lcm
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/nettest"
-	"golang.org/x/xerrors"
 )
 
 // Transmitter represents an LCM Transmitter instance.
@@ -35,30 +35,30 @@ func DialMulticastUDP(ctx context.Context, transmitterOpts ...TransmitterOption)
 	var listenConfig net.ListenConfig
 	c, err := listenConfig.ListenPacket(ctx, "udp4", "")
 	if err != nil {
-		return nil, xerrors.Errorf("dial multicast UDP: %w", err)
+		return nil, fmt.Errorf("dial multicast UDP: %w", err)
 	}
 	udpConn := c.(*net.UDPConn)
 	conn := ipv4.NewPacketConn(udpConn)
 	if err := conn.SetMulticastTTL(opts.ttl); err != nil {
-		return nil, xerrors.Errorf("dial multicast UDP: %w", err)
+		return nil, fmt.Errorf("dial multicast UDP: %w", err)
 	}
 	var ifi *net.Interface
 	if opts.interfaceName != "" {
 		ifi, err = net.InterfaceByName(opts.interfaceName)
 		if err != nil {
-			return nil, xerrors.Errorf("dial multicast UDP: failed to lookup provided if: %w", err)
+			return nil, fmt.Errorf("dial multicast UDP: failed to lookup provided if: %w", err)
 		}
 	} else {
 		ifi, err = getMulticastInterface()
 		if err != nil {
-			return nil, xerrors.Errorf("dial multicast UDP: failed to lookup multicast if: %w", err)
+			return nil, fmt.Errorf("dial multicast UDP: failed to lookup multicast if: %w", err)
 		}
 	}
 	if err := conn.SetMulticastInterface(ifi); err != nil {
-		return nil, xerrors.Errorf("dial multicast UDP: %w", err)
+		return nil, fmt.Errorf("dial multicast UDP: %w", err)
 	}
 	if err := conn.SetMulticastLoopback(opts.loopback); err != nil {
-		return nil, xerrors.Errorf("dial multicast UDP: %w", err)
+		return nil, fmt.Errorf("dial multicast UDP: %w", err)
 	}
 	tx := &Transmitter{opts: opts, conn: conn}
 	if len(opts.addrs) == 0 {
@@ -91,7 +91,7 @@ func (t *Transmitter) TransmitProto(ctx context.Context, m proto.Message) error 
 func (t *Transmitter) TransmitProtoOnChannel(ctx context.Context, channel string, m proto.Message) error {
 	t.protoBuf.Reset()
 	if err := t.protoBuf.Marshal(m); err != nil {
-		return xerrors.Errorf("transmit proto on channel %s: %w", channel, err)
+		return fmt.Errorf("transmit proto on channel %s: %w", channel, err)
 	}
 	return t.Transmit(ctx, channel, t.protoBuf.Bytes())
 }
@@ -103,7 +103,7 @@ func (t *Transmitter) Transmit(ctx context.Context, channel string, data []byte)
 	if compressor := t.opts.compressor[channel]; compressor != nil {
 		compressed, err := compressor.Compress(data)
 		if err != nil {
-			return xerrors.Errorf("transmit compress: %w", err)
+			return fmt.Errorf("transmit compress: %w", err)
 		}
 		t.msg.Data = compressed
 		t.msg.Params = "z=" + compressor.Name()
@@ -117,7 +117,7 @@ func (t *Transmitter) Transmit(ctx context.Context, channel string, data []byte)
 	t.sequenceNumber++
 	n, err := t.msg.marshal(t.payloadBuf[:])
 	if err != nil {
-		return xerrors.Errorf("transmit to LCM: %w", err)
+		return fmt.Errorf("transmit to LCM: %w", err)
 	}
 	for i := range t.messageBuf {
 		t.messageBuf[i].Buffers[0] = t.payloadBuf[:n]
@@ -125,12 +125,12 @@ func (t *Transmitter) Transmit(ctx context.Context, channel string, data []byte)
 	}
 	deadline, _ := ctx.Deadline()
 	if err := t.conn.SetWriteDeadline(deadline); err != nil {
-		return xerrors.Errorf("transmit to LCM: %w", err)
+		return fmt.Errorf("transmit to LCM: %w", err)
 	}
 	// fast-path: transmit to single address
 	if len(t.messageBuf) == 1 {
 		if _, err := t.conn.WriteTo(t.messageBuf[0].Buffers[0], nil, t.messageBuf[0].Addr); err != nil {
-			return xerrors.Errorf("transmit to LCM: %w", err)
+			return fmt.Errorf("transmit to LCM: %w", err)
 		}
 		return nil
 	}
@@ -139,7 +139,7 @@ func (t *Transmitter) Transmit(ctx context.Context, channel string, data []byte)
 	for transmitCount < len(t.messageBuf) {
 		n, err := t.conn.WriteBatch(t.messageBuf[transmitCount:], 0)
 		if err != nil {
-			return xerrors.Errorf("transmit to LCM: %w", err)
+			return fmt.Errorf("transmit to LCM: %w", err)
 		}
 		transmitCount += n
 	}
@@ -149,7 +149,7 @@ func (t *Transmitter) Transmit(ctx context.Context, channel string, data []byte)
 // Close the transmitter connection.
 func (t *Transmitter) Close() error {
 	if err := t.conn.Close(); err != nil {
-		return xerrors.Errorf("close LCM transmitter: %w", err)
+		return fmt.Errorf("close LCM transmitter: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Xerrors is now deprecated and replaced by fmt.Errorf with the %w
formatter.