### PR TITLE
chore(codeowners): transfer ownership to AET Data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
- *       @einride/team-awareness @odsod
+*       @einride/team-aet-data


### PR DESCRIPTION
Makes sense for our team to own this lib.

[Slack reference](https://einride.slack.com/archives/C034U29B7RB/p1647233743462819)