### PR TITLE
fix(gomod): retract v1.20.0, retract only version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,8 @@ require (
 )
 
 // Version has been removed from GitHub
-retract v1.19.0
+retract (
+	v1.20.0
+	v1.19.0
+	v1.0.0
+)


### PR DESCRIPTION
The retract done in 34007a2 to retract v1.19.0 haven't
kept dependabot from trying to bump to v1.19.0. Based on the
documentation in https://go.dev/ref/mod#go-mod-file-retract,
having a version retracting itself with a higher version number
than v1.19.0 may be the solution. Retract v1.20.0 in this commit
before creating the said versioned release.
