### PR TITLE
fix: handle context cancellation in receiver read

### DIFF
--- a/lcm_test.go
+++ b/lcm_test.go
@@ -74,6 +74,64 @@ func TestLCM_OneTransmitter_OneReceiver(t *testing.T) {
 	})
 }
 
+func TestLCM_Context(t *testing.T) {
+	t.Run("canceled", func(t *testing.T) {
+		// setup
+		const testTimeout = 1 * time.Second
+		ip := net.IPv4(239, 0, 0, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+		freePort := getFreePort(t)
+		ifi := getInterface(t)
+		rx, err := ListenMulticastUDP(
+			ctx,
+			WithReceiveInterface(ifi.Name),
+			WithReceivePort(freePort),
+			WithReceiveAddress(ip),
+		)
+		assert.NilError(t, err)
+		defer func() {
+			assert.NilError(t, rx.Close())
+		}()
+		// when the receiver receives
+		var g errgroup.Group
+		g.Go(func() error {
+			return rx.Receive(ctx)
+		})
+		// and when the context is canceled
+		cancel()
+		// then the receiver should receive context canceled error.
+		assert.ErrorIs(t, g.Wait(), context.Canceled)
+	})
+	t.Run("deadline exceeded", func(t *testing.T) {
+		// setup
+		const testTimeout = 200 * time.Millisecond
+		ip := net.IPv4(239, 0, 0, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+		freePort := getFreePort(t)
+		ifi := getInterface(t)
+		rx, err := ListenMulticastUDP(
+			ctx,
+			WithReceiveInterface(ifi.Name),
+			WithReceivePort(freePort),
+			WithReceiveAddress(ip),
+		)
+		assert.NilError(t, err)
+		defer func() {
+			assert.NilError(t, rx.Close())
+		}()
+		// when the receiver receives
+		var g errgroup.Group
+		g.Go(func() error {
+			return rx.Receive(ctx)
+		})
+		// and transmitter transmits nothing
+		// then the receiver should receive context deadline exceeded error.
+		assert.ErrorIs(t, g.Wait(), context.DeadlineExceeded)
+	})
+}
+
 func TestLCM_OneTransmitter_MultipleReceivers(t *testing.T) {
 	// setup
 	const testTimeout = 1 * time.Second

--- a/receiver.go
+++ b/receiver.go
@@ -123,13 +123,9 @@ func (r *Receiver) Receive(ctx context.Context) error {
 	r.protoMessage = nil
 	if r.messageBufIndex >= r.messageBufSize {
 		r.messageBufIndex = 0
-		deadline, _ := ctx.Deadline()
-		if err := r.conn.SetReadDeadline(deadline); err != nil {
-			return fmt.Errorf("receive on LCM: %w", err)
-		}
-		n, err := r.conn.ReadBatch(r.messageBuf, 0)
+		n, err := r.read(ctx)
 		if err != nil {
-			return fmt.Errorf("receive on LCM: %w", err)
+			return err
 		}
 		r.messageBufSize = n
 	}
@@ -157,6 +153,18 @@ func (r *Receiver) Receive(ctx context.Context) error {
 		r.currMessage.Data = data
 	}
 	return nil
+}
+
+func (r *Receiver) read(ctx context.Context) (int, error) {
+	deadline, _ := ctx.Deadline()
+	if err := r.conn.SetReadDeadline(deadline); err != nil {
+		return 0, fmt.Errorf("receive on LCM: %w", err)
+	}
+	n, err := r.conn.ReadBatch(r.messageBuf, 0)
+	if err != nil {
+		return n, fmt.Errorf("receive on LCM: %w", err)
+	}
+	return n, nil
 }
 
 // Receive a proto LCM message. The channel is assumed to be a fully-qualified message name.

--- a/receiver.go
+++ b/receiver.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"runtime"
 	"strings"
+	"time"
 
 	"go.einride.tech/lcm/compression/lcmlz4"
 	"golang.org/x/net/bpf"
@@ -118,7 +119,7 @@ type Receiver struct {
 
 // Receive an LCM message.
 //
-// If the provided context has a deadline, it will be propagated to the underlying read operation.
+// Receive blocks until a message arrives, ctx is canceled, or its deadline expires.
 func (r *Receiver) Receive(ctx context.Context) error {
 	r.protoMessage = nil
 	if r.messageBufIndex >= r.messageBufSize {
@@ -156,12 +157,35 @@ func (r *Receiver) Receive(ctx context.Context) error {
 }
 
 func (r *Receiver) read(ctx context.Context) (int, error) {
-	deadline, _ := ctx.Deadline()
-	if err := r.conn.SetReadDeadline(deadline); err != nil {
-		return 0, fmt.Errorf("receive on LCM: %w", err)
-	}
+	// start background routine that terminates in-progress read if
+	// context is canceled.
+	waitDone := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case <-ctx.Done():
+			// force the connection to terminate in-progress reads by setting a deadline
+			// in the past.
+			_ = r.conn.SetReadDeadline(time.Unix(1, 0))
+		case <-waitDone:
+			// read finished naturally, nothing to do.
+		}
+	}()
 	n, err := r.conn.ReadBatch(r.messageBuf, 0)
+
+	// clean up - shut down background thread
+	close(waitDone)
+	<-done
+	// reset the read deadline (ie. no read deadline).
+	_ = r.conn.SetReadDeadline(time.Time{})
+
 	if err != nil {
+		// The read failed because context was canceled and the read terminated,
+		// return that error.
+		if ctx.Err() != nil {
+			return n, fmt.Errorf("receive on LCM: %w", ctx.Err())
+		}
 		return n, fmt.Errorf("receive on LCM: %w", err)
 	}
 	return n, nil


### PR DESCRIPTION
- **refactor: break out the reading of lcm messages**
- **fix: handle context cancellation in receiver read**

Abort in-progress ReadBatch when context is canceled by setting a read
deadline in the past from a watcher goroutine, and return the context
error to the caller.